### PR TITLE
Ack API call removed during poll

### DIFF
--- a/pyconductor/ConductorWorker.py
+++ b/pyconductor/ConductorWorker.py
@@ -84,8 +84,7 @@ class ConductorWorker:
             time.sleep(float(self.polling_interval))
             polled = self.taskClient.pollForTask(taskType, self.worker_id, domain)
             if polled is not None:
-                if self.taskClient.ackTask(polled['taskId'], self.worker_id):
-                    self.execute(polled, exec_function)
+                self.execute(polled, exec_function)
 
     def start(self, taskType, exec_function, wait, domain=None):
         """

--- a/pyconductor/conductor.py
+++ b/pyconductor/conductor.py
@@ -213,14 +213,6 @@ class TaskClient(BaseClient):
             print('Error while polling ' + str(err))
             return None
 
-    def ackTask(self, taskId, workerid):
-        url = self.makeUrl('{}/ack', taskId)
-        params = {}
-        params['workerid'] = workerid
-        headers = {'Accept': 'application/json'}
-        value = self.post(url, params, None, headers)
-        return value in ['true', True]
-
     def getTasksInQueue(self, taskName):
         url = self.makeUrl('queue/{}', taskName)
         return self.get(url)


### PR DESCRIPTION
/tasks/{taskId}/ack endpoint is removed from conductor

reference:
https://github.com/Netflix/conductor/issues/1501

I have removed this API call during poll